### PR TITLE
Improve color accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -112,11 +112,11 @@ flowchart TB
     %% External Egress:
     GC --- LR
 
-    classDef commonPath fill:#f9f,stroke:#333,stroke-width:2px
-    classDef dynamicPath fill:#e1f5fe
-    classDef staticPath fill:#fff3e0
-    classDef storage fill:#e8f5e8
-    classDef security fill:#fce4ec
+    classDef commonPath fill:#00B5E2,stroke:#000000,stroke-width:2px
+    classDef dynamicPath fill:#9FC63B
+    classDef staticPath fill:#F18626
+    classDef storage fill:#FFD600
+    classDef security fill:#954B97
 
     class AS,BH,GC,ZS commonPath
     class DG,EB,IC1,IC2,EM dynamicPath

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,8 +7,8 @@
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     line-height: 1.6;
-    color: #333;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #000000;
+    background: linear-gradient(135deg, #00B5E2 0%, #954B97 100%);
     min-height: 100vh;
 }
 
@@ -45,10 +45,10 @@ header p {
 }
 
 .card h2 {
-    color: #2c3e50;
+    color: #000000;
     margin-bottom: 20px;
     font-size: 1.8rem;
-    border-bottom: 3px solid #3498db;
+    border-bottom: 3px solid #00B5E2;
     padding-bottom: 10px;
 }
 
@@ -73,14 +73,14 @@ header p {
 }
 
 .device-item strong {
-    color: #2c3e50;
+    color: #954B97;
     display: block;
     margin-bottom: 8px;
     font-size: 1.1rem;
 }
 
 .device-item p {
-    color: #666;
+    color: #6F6F6B;
     font-size: 0.95rem;
 }
 
@@ -101,20 +101,20 @@ header p {
 
 .path-item {
     background: #f8f9fa;
-    border-left: 4px solid #3498db;
+    border-left: 4px solid #00B5E2;
     padding: 15px;
     border-radius: 0 8px 8px 0;
 }
 
 .path-item h4 {
-    color: #2c3e50;
+    color: #000000;
     margin-bottom: 8px;
 }
 
 .path-item p {
     font-family: 'Courier New', monospace;
     font-size: 0.9rem;
-    color: #666;
+    color: #6F6F6B;
 }
 
 .test-category {
@@ -122,7 +122,7 @@ header p {
 }
 
 .test-category h3 {
-    color: #2c3e50;
+    color: #000000;
     margin-bottom: 15px;
     font-size: 1.3rem;
 }
@@ -134,14 +134,15 @@ header p {
     border-left: 4px solid #ddd;
 }
 
+
 .test-result.success {
-    border-left-color: #27ae60;
-    background: #d5f4e6;
+    border-left-color: #9FC63B;
+    background: rgba(159, 198, 59, 0.2);
 }
 
 .test-result.failure {
-    border-left-color: #e74c3c;
-    background: #fdeaea;
+    border-left-color: #F18626;
+    background: rgba(241, 134, 38, 0.2);
 }
 
 .status-badge {
@@ -153,19 +154,20 @@ header p {
     text-transform: uppercase;
 }
 
+
 .status-badge.success {
-    background: #27ae60;
-    color: white;
+    background: #9FC63B;
+    color: #000000;
 }
 
 .status-badge.failure {
-    background: #e74c3c;
-    color: white;
+    background: #F18626;
+    color: #000000;
 }
 
 .note {
     font-style: italic;
-    color: #666;
+    color: #6F6F6B;
     margin-top: 8px;
     font-size: 0.9rem;
 }
@@ -189,13 +191,13 @@ header p {
 }
 
 .diagnostic-section {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-    color: white;
+    background: linear-gradient(135deg, #F18626 0%, #FFD600 100%);
+    color: #000000;
 }
 
 .diagnostic-section h2 {
-    color: white;
-    border-bottom-color: rgba(255,255,255,0.3);
+    color: #000000;
+    border-bottom-color: rgba(0,0,0,0.3);
 }
 
 .diagnostic-form {
@@ -210,23 +212,23 @@ header p {
     display: block;
     margin-bottom: 8px;
     font-weight: bold;
-    color: white;
+    color: #000000;
 }
 
 .form-group select,
 .form-group textarea {
     width: 100%;
     padding: 12px;
-    border: 1px solid rgba(255,255,255,0.3);
+    border: 1px solid #6F6F6B;
     border-radius: 6px;
-    background: rgba(255,255,255,0.1);
-    color: white;
+    background: #ffffff;
+    color: #000000;
     font-size: 1rem;
 }
 
 .form-group select option {
-    background: #2c3e50;
-    color: white;
+    background: #00B5E2;
+    color: #000000;
 }
 
 .form-group textarea {
@@ -236,12 +238,12 @@ header p {
 
 .form-group select::placeholder,
 .form-group textarea::placeholder {
-    color: rgba(255,255,255,0.7);
+    color: #6F6F6B;
 }
 
 .submit-btn {
-    background: white;
-    color: #f5576c;
+    background: #00B5E2;
+    color: #FFFFFF;
     border: none;
     padding: 12px 30px;
     border-radius: 6px;
@@ -252,7 +254,7 @@ header p {
 }
 
 .submit-btn:hover {
-    background: #f8f9fa;
+    background: #954B97;
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
@@ -271,15 +273,15 @@ header p {
 }
 
 .feedback.success {
-    background: rgba(39, 174, 96, 0.2);
-    border: 1px solid rgba(39, 174, 96, 0.5);
-    color: #27ae60;
+    background: rgba(159, 198, 59, 0.2);
+    border: 1px solid rgba(159, 198, 59, 0.5);
+    color: #9FC63B;
 }
 
 .feedback.error {
-    background: rgba(231, 76, 60, 0.2);
-    border: 1px solid rgba(231, 76, 60, 0.5);
-    color: #e74c3c;
+    background: rgba(241, 134, 38, 0.2);
+    border: 1px solid rgba(241, 134, 38, 0.5);
+    color: #F18626;
 }
 
 .hidden {

--- a/public/styles.css
+++ b/public/styles.css
@@ -73,7 +73,7 @@ header p {
 }
 
 .device-item strong {
-    color: #954B97;
+    color: #000000;
     display: block;
     margin-bottom: 8px;
     font-size: 1.1rem;
@@ -191,7 +191,6 @@ header p {
 }
 
 .diagnostic-section {
-    background: linear-gradient(135deg, #F18626 0%, #FFD600 100%);
     color: #000000;
 }
 


### PR DESCRIPTION
## Summary
- restyle app using accessible color palette
- apply new gradient backgrounds and accents
- adjust mermaid diagram colors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd188d50832a96d6498087350408