### PR TITLE
Fix hint button style and rename app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Signal-Routing System Troubleshooter
+# Signal-Routing Troubleshooting Exercise
 
 An interactive web application for diagnosing faults in signal-routing systems. Based on network topology analysis and behavioral testing, users identify which device is misconfigured or faulty.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "signal-routing-troubleshooter",
+  "name": "signal-routing-troubleshooting-exercise",
   "version": "1.0.0",
   "description": "Interactive fault finding web app for signal-routing systems",
   "main": "server.js",

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Signal-Routing System Troubleshooter</title>
+    <title>Signal-Routing Troubleshooting Exercise</title>
     <link rel="stylesheet" href="styles.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.6.1/mermaid.min.js"></script>
 </head>
 <body>
     <div class="container">
         <header>
-            <h1>🔧 Signal-Routing System Troubleshooter</h1>
+            <h1>🔧 Signal-Routing Troubleshooting Exercise</h1>
             <p>Identify the faulty device based on observed behaviors and test results</p>
         </header>
 

--- a/public/script.js
+++ b/public/script.js
@@ -145,10 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Add hint button
     const hintBtn = document.createElement('button');
     hintBtn.textContent = '💡 Need a hint?';
-    hintBtn.className = 'submit-btn';
-    hintBtn.style.marginLeft = '10px';
-    hintBtn.style.background = 'rgba(255,255,255,0.2)';
-    hintBtn.style.color = 'white';
+    hintBtn.className = 'hint-btn submit-btn';
     
     hintBtn.addEventListener('click', function() {
         if (hintIndex < hints.length) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -264,6 +264,17 @@ header p {
     transform: none;
 }
 
+/* Hint button styling for better visibility */
+.hint-btn {
+    background: #954B97;
+    color: #FFFFFF;
+    margin-left: 10px;
+}
+
+.hint-btn:hover {
+    background: #00B5E2;
+}
+
 .feedback {
     margin-top: 20px;
     padding: 15px;

--- a/server.js
+++ b/server.js
@@ -35,5 +35,5 @@ app.post('/api/validate', (req, res) => {
 });
 
 app.listen(PORT, '0.0.0.0', () => {
-  console.log(`Signal Routing Troubleshooter running on port ${PORT}`);
+  console.log(`Signal-Routing Troubleshooting Exercise running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- rename the app to "Signal-Routing Troubleshooting Exercise"
- update headings and console message to the new name
- improve visibility for the hint button

## Testing
- `npm test` *(fails: Missing script)*
- `node --check server.js && node --check public/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840d08cf214832a98a9c48c57164d8e