### PR TITLE
Improve layout for legend and topology

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
         </header>
 
         <div class="content">
+            <div class="legend-topology">
             <!-- Device Legend Section -->
             <section class="card">
                 <h2>📋 Device Legend</h2>
@@ -146,6 +147,7 @@ flowchart TB
                     </div>
                 </div>
             </section>
+            </div>
 
             <!-- Test Results Section -->
             <section class="card">

--- a/public/styles.css
+++ b/public/styles.css
@@ -318,11 +318,26 @@ header p {
     .ping-results {
         grid-template-columns: 1fr;
     }
+
+    .legend-topology {
+        flex-direction: column;
+    }
 }
 
 /* Mermaid diagram styling */
 .mermaid {
     text-align: center;
+}
+
+/* Device Legend and Topology side-by-side layout */
+.legend-topology {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.legend-topology .card {
+    flex: 1;
 }
 
 /* Custom scrollbar for better UX */


### PR DESCRIPTION
## Summary
- wrap the device legend and topology sections in a new `legend-topology` container
- add flex styles so the two sections appear side by side
- ensure mobile view stacks the sections

## Testing
- `npm test` *(fails: missing script)*
- `npm install`
- `npm start` *(then Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_6840d3d65834832a8548d74ade93a37a