### PR TITLE
Adjust layout for legend and topology

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
         <div class="content">
             <div class="legend-topology">
             <!-- Device Legend Section -->
-            <section class="card">
+            <section class="card device-legend">
                 <h2>📋 Device Legend</h2>
                 <div class="device-grid">
                     <div class="device-item">
@@ -72,7 +72,7 @@
             </section>
 
             <!-- Topology Diagram Section -->
-            <section class="card">
+            <section class="card system-topology">
                 <h2>🗺️ System Topology</h2>
                 <div class="topology-container">
                     <pre class="mermaid">

--- a/public/styles.css
+++ b/public/styles.css
@@ -54,8 +54,8 @@ header p {
 
 .device-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 15px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
     margin-top: 20px;
 }
 
@@ -63,7 +63,7 @@ header p {
     background: #f8f9fa;
     border: 1px solid #e9ecef;
     border-radius: 8px;
-    padding: 15px;
+    padding: 10px;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -75,13 +75,13 @@ header p {
 .device-item strong {
     color: #000000;
     display: block;
-    margin-bottom: 8px;
-    font-size: 1.1rem;
+    margin-bottom: 6px;
+    font-size: 1rem;
 }
 
 .device-item p {
     color: #6F6F6B;
-    font-size: 0.95rem;
+    font-size: 0.85rem;
 }
 
 .topology-container {
@@ -336,8 +336,12 @@ header p {
     align-items: flex-start;
 }
 
-.legend-topology .card {
-    flex: 1;
+.legend-topology .device-legend {
+    flex: 0 0 40%;
+}
+
+.legend-topology .system-topology {
+    flex: 0 0 60%;
 }
 
 /* Custom scrollbar for better UX */


### PR DESCRIPTION
## Summary
- tweak Device Legend and System Topology layout with new 40/60 flex split
- compact Device Legend items and grid to shorten the list

## Testing
- `npm install`
- `npm start` *(fails: cannot listen on address in CI)*

------
https://chatgpt.com/codex/tasks/task_e_6840d553d3b0832aa52a6f6f34eeddfb