### PR TITLE
Fix width alignment and dropdown style

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -150,7 +150,7 @@ flowchart TB
             </div>
 
             <!-- Test Results Section -->
-            <section class="card">
+            <section class="card test-results">
                 <h2>🧪 Observed Test Results</h2>
                 
                 <div class="test-category">

--- a/public/styles.css
+++ b/public/styles.css
@@ -190,8 +190,11 @@ header p {
     font-size: 0.9rem;
 }
 
+.test-results,
 .diagnostic-section {
     color: #000000;
+    width: calc(100% + 20px);
+    margin: 0 -10px;
 }
 
 .diagnostic-section h2 {
@@ -226,7 +229,7 @@ header p {
 }
 
 .form-group select option {
-    background: #00B5E2;
+    background: #ffffff;
     color: #000000;
 }
 
@@ -321,6 +324,12 @@ header p {
 
     .legend-topology {
         flex-direction: column;
+    }
+
+    .test-results,
+    .diagnostic-section {
+        width: 100%;
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- expand *Observed Test Results* and *Your Diagnosis* sections so their width matches the `Device Legend` + `System Topology` layout
- set dropdown options to have white backgrounds

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840d85140e8832a971df44b484f15ec