### PR TITLE
Fix layout width alignment and dropdown style

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -228,7 +228,7 @@ header p {
 }
 
 .form-group select option {
-    background: #00B5E2;
+    background: #ffffff;
     color: #000000;
 }
 
@@ -339,11 +339,11 @@ header p {
 }
 
 .legend-topology .device-legend {
-    flex: 0 0 40%;
+    flex: 0 0 calc(40% - 10px);
 }
 
 .legend-topology .system-topology {
-    flex: 0 0 60%;
+    flex: 0 0 calc(60% - 10px);
 }
 
 /* Custom scrollbar for better UX */


### PR DESCRIPTION
## Summary
- ensure side-by-side boxes don't overflow by subtracting gap from widths
- set select option background to white for better visibility

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840dbf322b8832aaea3f53ad8598a23