### PR TITLE
Add introductory overview box

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,13 @@
     <div class="container">
         <header>
             <h1>🔧 Signal-Routing Troubleshooting Exercise</h1>
-            <p>Identify the faulty device based on observed behaviors and test results</p>
         </header>
+
+        <section class="card overview-box">
+            <h2>Exercise Overview</h2>
+            <p>This simulation presents a signal-routing system where every request first flows through AlphaStation, BetaHub, GammaCore and ZetaSplit.</p>
+            <p>Dynamic signals then run through a processing cluster before reaching storage, while static signals pass two security gateways. Use the information below to identify the misbehaving device.</p>
+        </section>
 
         <div class="content">
             <div class="legend-topology">


### PR DESCRIPTION
## Summary
- add a brief "Exercise Overview" card at the start of the page
- remove the old subheading under the page title

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5f7999c832ab621d590d4c3bf91