### PR TITLE
Add YAML-configurable troubleshooting scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "signal-routing-troubleshooter",
+  "name": "signal-routing-troubleshooting-exercise",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "signal-routing-troubleshooter",
+      "name": "signal-routing-troubleshooting-exercise",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
+        "js-yaml": "^4.1.0",
         "path": "^0.12.7"
       },
       "devDependencies": {
@@ -42,6 +43,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -634,6 +641,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/public/index.html
+++ b/public/index.html
@@ -10,13 +10,11 @@
 <body>
     <div class="container">
         <header>
-            <h1>🔧 Signal-Routing Troubleshooting Exercise</h1>
+            <h1 id="pageTitle">🔧 Troubleshooting Exercise</h1>
         </header>
 
-        <section class="card overview-box">
-            <h2>Exercise Overview</h2>
-            <p>This simulation presents a signal-routing system where every request first flows through AlphaStation, BetaHub, GammaCore and ZetaSplit.</p>
-            <p>Dynamic signals then run through a processing cluster before reaching storage, while static signals pass two security gateways. Use the information below to identify the misbehaving device.</p>
+        <section class="card overview-box" id="overviewSection">
+            <!-- Overview text will be inserted here -->
         </section>
 
         <div class="content">
@@ -24,177 +22,21 @@
             <!-- Device Legend Section -->
             <section class="card device-legend">
                 <h2>📋 Device Legend</h2>
-                <div class="device-grid">
-                    <div class="device-item">
-                        <strong>AS - AlphaStation</strong>
-                        <p>Labels each incoming signal as dynamic or static, then forwards to BetaHub</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>BH - BetaHub</strong>
-                        <p>Aggregator: collects signals from AlphaStation, tags them "ready," sends upstream to GammaCore</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>GC - GammaCore</strong>
-                        <p>Central nexus: inspects each incoming signal and sends all traffic to ZetaSplit first</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>ZS - ZetaSplit</strong>
-                        <p>Splits dynamic signal into two identical streams for parallel processing. Static signals pass through unchanged</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>DG - DeltaGate</strong>
-                        <p>Filter: allows only "priority-dynamic" signals through; drops non-priority dynamic. All static signals are dropped</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>EB - EtaBalancer</strong>
-                        <p>Balancer: takes signals from DeltaGate and distributes them (round-robin) to IotaCompute nodes</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>IC₁/IC₂ - IotaCompute</strong>
-                        <p>Compute nodes: process dynamic streams, forward "processed-dynamic" output to EpsilonMerge. Static never reaches IC</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>EM - EpsilonMerge</strong>
-                        <p>Merger: combines two "processed-dynamic" streams into one consolidated stream and sends to KappaStore</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>KS - KappaStore</strong>
-                        <p>Storage node: holds both static assets (pure archive data) and merged dynamic results (from EM)</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>TF1 - ThetaFire-A</strong>
-                        <p>Stage-1 security gateway for static traffic only. Static signals are sent here; forwards to TF2. Dynamic signals do not go to TF1</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>TF2 - ThetaFire-B</strong>
-                        <p>Stage-2 security gateway for static traffic only. Performs deeper policy checks before forwarding static to KappaStore</p>
-                    </div>
-                    <div class="device-item">
-                        <strong>LR - LambdaRouter</strong>
-                        <p>Egress node: requests tagged "external" are sent here (irrelevant to storage)</p>
-                    </div>
-                </div>
+                <div class="device-grid" id="deviceGrid"></div>
             </section>
 
             <!-- Topology Diagram Section -->
             <section class="card system-topology">
                 <h2>🗺️ System Topology</h2>
                 <div class="topology-container">
-                    <pre class="mermaid">
-flowchart TB
-    AS["🖥️ AlphaStation (AS)"]
-    BH["🔀 BetaHub (BH)"]
-    GC["🔹 GammaCore (GC)"]
-    ZS["↗️ ZetaSplit (ZS)"]
-    DG["⚠️ DeltaGate (DG)"]
-    EB["⚖️ EtaBalancer (EB)"]
-    IC1["⚙️ IotaCompute 1 (IC₁)"]
-    IC2["⚙️ IotaCompute 2 (IC₂)"]
-    EM["🔗 EpsilonMerge (EM)"]
-    KS["💾 KappaStore (KS)"]
-    TF1["🛡️ ThetaFire-A (TF1)"]
-    TF2["🛡️ ThetaFire-B (TF2)"]
-    LR["🌐 LambdaRouter (LR)"]
-
-    %% Common Upstream:
-    AS --- BH
-    BH --- GC
-    GC --- ZS
-
-    %% Dynamic Path:
-    ZS --- DG
-    DG --- EB
-    EB --- IC1
-    EB --- IC2
-    IC1 --- EM
-    IC2 --- EM
-    EM --- KS
-
-    %% Static Path:
-    ZS --- TF1
-    TF1 --- TF2
-    TF2 --- KS
-
-    %% External Egress:
-    GC --- LR
-
-    classDef commonPath fill:#00B5E2,stroke:#000000,stroke-width:2px
-    classDef dynamicPath fill:#9FC63B
-    classDef staticPath fill:#F18626
-    classDef storage fill:#FFD600
-    classDef security fill:#954B97
-
-    class AS,BH,GC,ZS commonPath
-    class DG,EB,IC1,IC2,EM dynamicPath
-    class TF1,TF2 security
-    class KS storage
-                    </pre>
+                    <pre class="mermaid" id="topologyDiagram"></pre>
                 </div>
-                
-                <div class="path-info">
-                    <div class="path-item">
-                        <h4>🟣 Common Upstream Path</h4>
-                        <p>AS → BH → GC → ZS (all traffic flows through here first)</p>
-                    </div>
-                    <div class="path-item">
-                        <h4>🔵 Dynamic Path (Processing Cluster)</h4>
-                        <p>ZS → DG → EB → IC₁ & IC₂ → EM → KS</p>
-                        <small>ZetaSplit duplicates dynamic signals; only priority-dynamic survives DeltaGate</small>
-                    </div>
-                    <div class="path-item">
-                        <h4>🟠 Static Path (Archive)</h4>
-                        <p>ZS → TF1 → TF2 → KS</p>
-                        <small>ZetaSplit passes static signals unchanged to security gateways</small>
-                    </div>
-                    <div class="path-item">
-                        <h4>🌐 External Egress</h4>
-                        <p>GC → LR (irrelevant to storage)</p>
-                    </div>
-                </div>
+                <div class="path-info" id="pathInfo"></div>
             </section>
             </div>
 
             <!-- Test Results Section -->
-            <section class="card">
-                <h2>🧪 Observed Test Results</h2>
-                
-                <div class="test-category">
-                    <h3>✅ Dynamic Requests (Working)</h3>
-                    <div class="test-result success">
-                        <p><strong>From AlphaStation (AS):</strong></p>
-                        <p>Every request labeled "dynamic" (priority or non-priority) that should run through the dynamic pipeline (ZS→DG→EB→IC₁/IC₂→EM→KS) <span class="status-badge success">SUCCESS</span></p>
-                        <p class="note">This confirms that priority-dynamic splitting, load-balancing, computing, merging, and final storage into KS all work correctly.</p>
-                    </div>
-                </div>
-
-                <div class="test-category">
-                    <h3>❌ Static Requests (Failing)</h3>
-                    <div class="test-result failure">
-                        <p><strong>From GammaCore (GC) or upstream:</strong></p>
-                        <p>Every request labeled "static" that should follow (ZS→TF1→TF2→KS) <span class="status-badge failure">TIMEOUT/REJECTED</span></p>
-                        <p class="note">Important: No explicit "destination unreachable" message—requests simply never complete.</p>
-                    </div>
-                </div>
-
-                <div class="test-category">
-                    <h3>🏓 Ping/Reachability Tests (All Working)</h3>
-                    <div class="ping-results">
-                        <div class="ping-item">GC → ZS <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">ZS → DG <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">DG → EB <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">EB → IC₁ <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">EB → IC₂ <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">IC₁ → EM <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">IC₂ → EM <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">EM → KS <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">ZS → TF1 <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">TF1 → TF2 <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">TF2 → KS <span class="status-badge success">✅</span></div>
-                        <div class="ping-item">GC → LR <span class="status-badge success">✅</span></div>
-                    </div>
-                    <p class="note">All links and devices respond to ping—no broken cables or physical connectivity issues.</p>
-                </div>
-            </section>
+            <section class="card" id="testResults"></section>
 
             <!-- Diagnostic Section -->
             <section class="card diagnostic-section">
@@ -204,27 +46,14 @@ flowchart TB
                         <label for="deviceSelect">Which device is faulty?</label>
                         <select id="deviceSelect" required>
                             <option value="">Select a device...</option>
-                            <option value="AS">AS - AlphaStation</option>
-                            <option value="BH">BH - BetaHub</option>
-                            <option value="GC">GC - GammaCore</option>
-                            <option value="ZS">ZS - ZetaSplit</option>
-                            <option value="DG">DG - DeltaGate</option>
-                            <option value="EB">EB - EtaBalancer</option>
-                            <option value="IC1">IC₁ - IotaCompute 1</option>
-                            <option value="IC2">IC₂ - IotaCompute 2</option>
-                            <option value="EM">EM - EpsilonMerge</option>
-                            <option value="KS">KS - KappaStore</option>
-                            <option value="TF1">TF1 - ThetaFire-A</option>
-                            <option value="TF2">TF2 - ThetaFire-B</option>
-                            <option value="LR">LR - LambdaRouter</option>
                         </select>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="reasoning">Explain your reasoning (2-3 sentences):</label>
                         <textarea id="reasoning" rows="4" placeholder="How did you rule out other devices? Why is this device the culprit?"></textarea>
                     </div>
-                    
+
                     <button id="submitBtn" class="submit-btn">Submit Diagnosis</button>
                 </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -247,4 +247,4 @@ function populateScenario(data) {
     });
     
     submitBtn.parentNode.appendChild(hintBtn);
-});
+}

--- a/scenario.yaml
+++ b/scenario.yaml
@@ -1,0 +1,137 @@
+title: "Signal-Routing Troubleshooting Exercise"
+overview: |
+  This simulation presents a signal-routing system where every request first flows through AlphaStation, BetaHub, GammaCore and ZetaSplit.
+  Dynamic signals then run through a processing cluster before reaching storage, while static signals pass two security gateways. Use the information below to identify the misbehaving device.
+
+devices:
+  - id: "AS"
+    name: "AlphaStation"
+    description: "Labels each incoming signal as dynamic or static, then forwards to BetaHub"
+  - id: "BH"
+    name: "BetaHub"
+    description: "Aggregator: collects signals from AlphaStation, tags them 'ready,' sends upstream to GammaCore"
+  - id: "GC"
+    name: "GammaCore"
+    description: "Central nexus: inspects each incoming signal and sends all traffic to ZetaSplit first"
+  - id: "ZS"
+    name: "ZetaSplit"
+    description: "Splits dynamic signal into two identical streams for parallel processing. Static signals pass through unchanged"
+  - id: "DG"
+    name: "DeltaGate"
+    description: "Filter: allows only 'priority-dynamic' signals through; drops non-priority dynamic. All static signals are dropped"
+  - id: "EB"
+    name: "EtaBalancer"
+    description: "Balancer: takes signals from DeltaGate and distributes them (round-robin) to IotaCompute nodes"
+  - id: "IC1"
+    name: "IotaCompute 1"
+    description: "Compute node: processes dynamic streams, forwards 'processed-dynamic' output to EpsilonMerge"
+  - id: "IC2"
+    name: "IotaCompute 2"
+    description: "Compute node: processes dynamic streams, forwards 'processed-dynamic' output to EpsilonMerge"
+  - id: "EM"
+    name: "EpsilonMerge"
+    description: "Merger: combines two 'processed-dynamic' streams into one consolidated stream and sends to KappaStore"
+  - id: "KS"
+    name: "KappaStore"
+    description: "Storage node: holds both static assets (pure archive data) and merged dynamic results (from EM)"
+  - id: "TF1"
+    name: "ThetaFire-A"
+    description: "Stage-1 security gateway for static traffic only. Static signals are sent here; forwards to TF2. Dynamic signals do not go to TF1"
+  - id: "TF2"
+    name: "ThetaFire-B"
+    description: "Stage-2 security gateway for static traffic only. Performs deeper policy checks before forwarding static to KappaStore"
+  - id: "LR"
+    name: "LambdaRouter"
+    description: "Egress node: requests tagged 'external' are sent here (irrelevant to storage)"
+
+topology: |
+  flowchart TB
+      AS["🖥️ AlphaStation (AS)"]
+      BH["🔀 BetaHub (BH)"]
+      GC["🔹 GammaCore (GC)"]
+      ZS["↗️ ZetaSplit (ZS)"]
+      DG["⚠️ DeltaGate (DG)"]
+      EB["⚖️ EtaBalancer (EB)"]
+      IC1["⚙️ IotaCompute 1 (IC₁)"]
+      IC2["⚙️ IotaCompute 2 (IC₂)"]
+      EM["🔗 EpsilonMerge (EM)"]
+      KS["💾 KappaStore (KS)"]
+      TF1["🛡️ ThetaFire-A (TF1)"]
+      TF2["🛡️ ThetaFire-B (TF2)"]
+      LR["🌐 LambdaRouter (LR)"]
+
+      %% Common Upstream:
+      AS --- BH
+      BH --- GC
+      GC --- ZS
+
+      %% Dynamic Path:
+      ZS --- DG
+      DG --- EB
+      EB --- IC1
+      EB --- IC2
+      IC1 --- EM
+      IC2 --- EM
+      EM --- KS
+
+      %% Static Path:
+      ZS --- TF1
+      TF1 --- TF2
+      TF2 --- KS
+
+      %% External Egress:
+      GC --- LR
+
+paths:
+  - title: "Common Upstream Path"
+    description: "AS → BH → GC → ZS (all traffic flows through here first)"
+  - title: "Dynamic Path (Processing Cluster)"
+    description: "ZS → DG → EB → IC₁ & IC₂ → EM → KS"
+    note: "ZetaSplit duplicates dynamic signals; only priority-dynamic survives DeltaGate"
+  - title: "Static Path (Archive)"
+    description: "ZS → TF1 → TF2 → KS"
+    note: "ZetaSplit passes static signals unchanged to security gateways"
+  - title: "External Egress"
+    description: "GC → LR (irrelevant to storage)"
+
+test_results:
+  dynamic:
+    heading: "Dynamic Requests (Working)"
+    details: |
+      From AlphaStation (AS):
+      Every request labeled "dynamic" (priority or non-priority) that should run through the dynamic pipeline (ZS→DG→EB→IC₁/IC₂→EM→KS) SUCCESS
+      This confirms that priority-dynamic splitting, load-balancing, computing, merging, and final storage into KS all work correctly.
+  static:
+    heading: "Static Requests (Failing)"
+    details: |
+      From GammaCore (GC) or upstream:
+      Every request labeled "static" that should follow (ZS→TF1→TF2→KS) TIMEOUT/REJECTED
+      Important: No explicit "destination unreachable" message—requests simply never complete.
+  ping:
+    heading: "Ping/Reachability Tests (All Working)"
+    results:
+      - "GC → ZS"
+      - "ZS → DG"
+      - "DG → EB"
+      - "EB → IC₁"
+      - "EB → IC₂"
+      - "IC₁ → EM"
+      - "IC₂ → EM"
+      - "EM → KS"
+      - "ZS → TF1"
+      - "TF1 → TF2"
+      - "TF2 → KS"
+      - "GC → LR"
+    note: "All links and devices respond to ping—no broken cables or physical connectivity issues."
+
+hints:
+  - "Notice that both dynamic and static traffic share the same upstream path through AS→BH→GC→ZS..."
+  - "All ping tests succeed, so it's not a connectivity issue anywhere in the network..."
+  - "Dynamic requests work end-to-end through the entire shared path and processing cluster..."
+  - "Static requests fail after ZetaSplit, but ZS→TF1 and TF1→TF2 both respond to ping..."
+  - "The failure happens somewhere in the static security gateway chain, but which stage?"
+
+validation:
+  correct_answer: "TF2"
+  success_feedback: "Correct! TF2 (ThetaFire-B) is indeed the faulty device. Since all pings succeed (including ZS→TF1, TF1→TF2, TF2→KS) and all dynamic requests work through the shared upstream path, the problem must be TF2's internal policy dropping all static traffic despite being reachable."
+  failure_feedback: "Incorrect. The faulty device is TF2. Key insight: Dynamic requests work end-to-end through AS→BH→GC→ZS→DG→EB→IC→EM→KS, proving all those devices work. Static requests fail in the ZS→TF1→TF2→KS path, but all hops respond to ping. This points to TF2's internal filtering logic being broken."


### PR DESCRIPTION
## Summary
- allow scenario to be defined via `scenario.yaml`
- load YAML config in server and expose via `/api/scenario`
- refactor answer validation to use YAML data
- update frontend to render page from config
- include default scenario YAML

## Testing
- `npm install`
- `node server.js &` then `curl http://localhost:3000/api/scenario` and `curl .../api/validate`

------
https://chatgpt.com/codex/tasks/task_e_6840e9e43a4c832a9f4bcf2ea4291507