### PR TITLE
Add explicit statuses for test results

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -72,30 +72,55 @@ function populateScenario(data) {
     const testSection = document.getElementById('testResults');
     testSection.innerHTML = '<h2>🧪 Observed Test Results</h2>';
 
-    const dyn = document.createElement('div');
-    dyn.className = 'test-category';
-    dyn.innerHTML = `<h3>✅ ${data.test_results.dynamic.heading}</h3><div class="test-result success">` +
-        data.test_results.dynamic.details.split('\n').map(p => `<p>${p}</p>`).join('') +
-        '</div>';
-    testSection.appendChild(dyn);
+    Object.keys(data.test_results).forEach(key => {
+        const result = data.test_results[key];
 
-    const sta = document.createElement('div');
-    sta.className = 'test-category';
-    sta.innerHTML = `<h3>❌ ${data.test_results.static.heading}</h3><div class="test-result failure">` +
-        data.test_results.static.details.split('\n').map(p => `<p>${p}</p>`).join('') +
-        '</div>';
-    testSection.appendChild(sta);
+        if (key === 'ping' && Array.isArray(result.results)) {
+            const ping = document.createElement('div');
+            ping.className = 'test-category';
 
-    const ping = document.createElement('div');
-    ping.className = 'test-category';
-    let pingHtml = `<h3>🏓 ${data.test_results.ping.heading}</h3><div class="ping-results">`;
-    data.test_results.ping.results.forEach(r => {
-        pingHtml += `<div class="ping-item">${r} <span class="status-badge success">✅</span></div>`;
+            let pingHtml = `<h3>🏓 ${result.heading}</h3><div class="ping-results">`;
+            result.results.forEach(r => {
+                pingHtml += `<div class="ping-item">${r} <span class="status-badge success">✅</span></div>`;
+            });
+            pingHtml += '</div>';
+            if (result.note) {
+                pingHtml += `<p class="note">${result.note}</p>`;
+            }
+            ping.innerHTML = pingHtml;
+            testSection.appendChild(ping);
+        } else if (result && result.heading && result.details) {
+            const div = document.createElement('div');
+            div.className = 'test-category';
+
+            let statusClass = '';
+            let icon = 'ℹ️';
+            const status = (result.status || '').toLowerCase();
+            if (['success', 'pass', 'working'].includes(status)) {
+                icon = '✅';
+                statusClass = 'success';
+            } else if (['failure', 'fail'].includes(status)) {
+                icon = '❌';
+                statusClass = 'failure';
+            } else if (status === 'info') {
+                icon = 'ℹ️';
+            } else {
+                const lower = result.heading.toLowerCase();
+                if (lower.includes('working') || lower.includes('pass')) {
+                    icon = '✅';
+                    statusClass = 'success';
+                } else if (lower.includes('fail')) {
+                    icon = '❌';
+                    statusClass = 'failure';
+                }
+            }
+
+            div.innerHTML = `<h3>${icon} ${result.heading}</h3><div class="test-result ${statusClass}">` +
+                result.details.split('\n').map(p => `<p>${p}</p>`).join('') +
+                '</div>';
+            testSection.appendChild(div);
+        }
     });
-    pingHtml += '</div>';
-    pingHtml += `<p class="note">${data.test_results.ping.note}</p>`;
-    ping.innerHTML = pingHtml;
-    testSection.appendChild(ping);
 
     hints = data.hints || [];
 }

--- a/scenario.yaml
+++ b/scenario.yaml
@@ -87,19 +87,22 @@ paths:
 test_results:
   sweet:
     heading: "Sweet Production Run (Working)"
+    status: success
     details: |
-      A batch of sweet items using the sweet recipe at RawMixer 
+      A batch of sweet items using the sweet recipe at RawMixer
       passes through Sheeter, Oven, Splitter, FrostingLine, and QualityCheck,
       then moves on to ShadingLamp and Packer successfully.
   savory:
     heading: "Savory Production Run (Failing)"
+    status: failure
     details: |
-      A batch of savory items using the savory recipe at RawMixer 
+      A batch of savory items using the savory recipe at RawMixer
       follows the path through Sheeter, Oven, Splitter, SpiceLine, and
       reaches QualityCheck but is always marked 'defective' and rejected,
       despite no visible defects.
   spot_checks:
     heading: "Spot‐Checks at Each Machine"
+    status: info
     details: |
       - RawMixer: Dough consistency and texture pass for both sweet and savory.
       - Sheeter: Sheet thickness is correct for both types.
@@ -111,18 +114,19 @@ test_results:
       - ShadingLamp: Receives and passes sweet items; never receives savory because QC rejects them.
       - Packer: Packages accepted items only (receives none from savory).
 
-ping:
-  heading: "Machine‐to‐Machine Handshake Tests (All Working)"
-  results:
-    - "RM → SH"
-    - "SH → OV"
-    - "OV → SPT"
-    - "SPT → FR"
-    - "SPT → SPC"
-    - "FR → QC"
-    - "SPC → QC"
-    - "QC → SHD"
-    - "SHD → PK"
+  ping:
+    heading: "Machine‐to‐Machine Handshake Tests (All Working)"
+    status: success
+    results:
+      - "RM → SH"
+      - "SH → OV"
+      - "OV → SPT"
+      - "SPT → FR"
+      - "SPT → SPC"
+      - "FR → QC"
+      - "SPC → QC"
+      - "QC → SHD"
+      - "SHD → PK"
   note: |
     All handshake tests succeed—no machine is physically offline or disconnected.
 


### PR DESCRIPTION
## Summary
- specify `status` for each test result category in scenario.yaml
- render success/failure/info icons in the frontend based on these statuses

## Testing
- `npm install`
- `node --check server.js`
- `node --check public/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841283b1a74832a8950f37676597358