### PR TITLE
Improve scenario upload UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,13 +12,13 @@
         <header>
             <h1 id="pageTitle">🔧 Troubleshooting Exercise</h1>
             <div class="scenario-menu">
-                <button id="scenarioToggle" class="scenario-btn">⚙️ Scenarios</button>
-                <div id="scenarioControls" class="scenario-controls hidden">
+                <button id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false">⚙️ Scenarios</button>
+                <div id="scenarioControls" class="scenario-controls hidden" role="menu">
+                    <label for="scenarioSelect" class="visually-hidden">Scenario</label>
                     <select id="scenarioSelect"></select>
-                    <label class="upload-label">
-                        <input type="file" id="scenarioFile" accept=".yaml,.yml" class="hidden">
-                        <span id="scenarioUploadBtn" class="scenario-upload">Upload</span>
-                    </label>
+                    <label for="scenarioFile" class="scenario-upload btn-file">Choose File</label>
+                    <input type="file" id="scenarioFile" accept=".yaml,.yml" class="visually-hidden">
+                    <button id="scenarioUploadBtn" class="scenario-upload-btn" disabled>Upload</button>
                 </div>
             </div>
         </header>

--- a/public/index.html
+++ b/public/index.html
@@ -16,9 +16,9 @@
                 <div id="scenarioControls" class="scenario-controls hidden" role="menu">
                     <label for="scenarioSelect" class="visually-hidden">Scenario</label>
                     <select id="scenarioSelect"></select>
-                    <label for="scenarioFile" class="scenario-upload btn-file">Choose File</label>
+                    <label for="scenarioFile" class="btn-file submit-btn">Choose File</label>
                     <input type="file" id="scenarioFile" accept=".yaml,.yml" class="visually-hidden">
-                    <button id="scenarioUploadBtn" class="scenario-upload-btn" disabled>Upload</button>
+                    <button id="scenarioUploadBtn" class="submit-btn scenario-upload-btn" disabled>Upload</button>
                 </div>
             </div>
         </header>

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
         <header>
             <h1 id="pageTitle">🔧 Troubleshooting Exercise</h1>
             <div class="scenario-menu">
-                <button id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false">⚙️ Scenarios</button>
+                <button id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false" aria-label="Scenarios" title="Scenarios">⚙️</button>
                 <div id="scenarioControls" class="scenario-controls hidden" role="menu">
                     <label for="scenarioSelect" class="visually-hidden">Scenario</label>
                     <select id="scenarioSelect"></select>

--- a/public/index.html
+++ b/public/index.html
@@ -11,16 +11,16 @@
     <div class="container">
         <header>
             <h1 id="pageTitle">🔧 Troubleshooting Exercise</h1>
-            <div class="scenario-menu">
-                <button id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false" aria-label="Scenarios" title="Scenarios">⚙️</button>
-                <div id="scenarioControls" class="scenario-controls hidden" role="menu">
+            <details id="scenarioMenu" class="scenario-menu">
+                <summary id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false" aria-label="Scenarios" title="Scenarios">⚙️</summary>
+                <div id="scenarioControls" class="scenario-controls" role="menu">
                     <label for="scenarioSelect" class="visually-hidden">Scenario</label>
                     <select id="scenarioSelect"></select>
                     <label for="scenarioFile" class="btn-file submit-btn">Choose File</label>
                     <input type="file" id="scenarioFile" accept=".yaml,.yml" class="visually-hidden">
                     <button id="scenarioUploadBtn" class="submit-btn scenario-upload-btn" disabled>Upload</button>
                 </div>
-            </div>
+            </details>
         </header>
 
         <section class="card overview-box" id="overviewSection">

--- a/public/index.html
+++ b/public/index.html
@@ -12,9 +12,9 @@
         <header>
             <h1 id="pageTitle">🔧 Troubleshooting Exercise</h1>
             <details id="scenarioMenu" class="scenario-menu">
-                <summary id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false" aria-label="Scenarios" title="Scenarios">⚙️</summary>
+                <summary id="scenarioToggle" class="scenario-btn" aria-haspopup="true" aria-expanded="false" aria-label="Scenarios" title="Scenarios">&#9776;</summary>
                 <div id="scenarioControls" class="scenario-controls" role="menu">
-                    <label for="scenarioSelect" class="visually-hidden">Scenario</label>
+                    <label for="scenarioSelect" class="menu-title">Select Scenario:</label>
                     <select id="scenarioSelect"></select>
                     <label for="scenarioFile" class="btn-file submit-btn">Choose File</label>
                     <input type="file" id="scenarioFile" accept=".yaml,.yml" class="visually-hidden">

--- a/public/script.js
+++ b/public/script.js
@@ -15,17 +15,28 @@ async function init() {
     const uploadBtn = document.getElementById('scenarioUploadBtn');
     const fileInput = document.getElementById('scenarioFile');
 
-    scenarioToggle.addEventListener('click', () => {
+    function hideScenarioMenu() {
+        if (!scenarioControls.classList.contains('hidden')) {
+            scenarioControls.classList.add('hidden');
+            scenarioToggle.setAttribute('aria-expanded', 'false');
+        }
+    }
+
+    scenarioToggle.addEventListener('click', (e) => {
+        e.stopPropagation();
         const hidden = scenarioControls.classList.toggle('hidden');
         scenarioToggle.setAttribute('aria-expanded', String(!hidden));
     });
 
     document.addEventListener('click', (e) => {
         if (!scenarioMenu.contains(e.target)) {
-            if (!scenarioControls.classList.contains('hidden')) {
-                scenarioControls.classList.add('hidden');
-                scenarioToggle.setAttribute('aria-expanded', 'false');
-            }
+            hideScenarioMenu();
+        }
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            hideScenarioMenu();
         }
     });
 
@@ -178,6 +189,7 @@ async function loadScenario(name) {
         currentScenario = scenarioSelect.value;
         await loadScenario(currentScenario);
         checkFormValidity();
+        hideScenarioMenu();
     });
 
     uploadBtn.addEventListener('click', async () => {
@@ -206,6 +218,7 @@ async function loadScenario(name) {
             await loadScenario(currentScenario);
             checkFormValidity();
             fileInput.value = '';
+            hideScenarioMenu();
         } catch (err) {
             console.error('Upload failed', err);
         } finally {

--- a/public/script.js
+++ b/public/script.js
@@ -11,12 +11,22 @@ async function init() {
     const scenarioSelect = document.getElementById('scenarioSelect');
     const scenarioToggle = document.getElementById('scenarioToggle');
     const scenarioControls = document.getElementById('scenarioControls');
+    const scenarioMenu = document.querySelector('.scenario-menu');
     const uploadBtn = document.getElementById('scenarioUploadBtn');
     const fileInput = document.getElementById('scenarioFile');
 
     scenarioToggle.addEventListener('click', () => {
         const hidden = scenarioControls.classList.toggle('hidden');
         scenarioToggle.setAttribute('aria-expanded', String(!hidden));
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!scenarioMenu.contains(e.target)) {
+            if (!scenarioControls.classList.contains('hidden')) {
+                scenarioControls.classList.add('hidden');
+                scenarioToggle.setAttribute('aria-expanded', 'false');
+            }
+        }
     });
 
     fileInput.addEventListener('change', () => {

--- a/public/script.js
+++ b/public/script.js
@@ -11,21 +11,19 @@ async function init() {
     const scenarioSelect = document.getElementById('scenarioSelect');
     const scenarioToggle = document.getElementById('scenarioToggle');
     const scenarioControls = document.getElementById('scenarioControls');
-    const scenarioMenu = document.querySelector('.scenario-menu');
+    const scenarioMenu = document.getElementById('scenarioMenu');
     const uploadBtn = document.getElementById('scenarioUploadBtn');
     const fileInput = document.getElementById('scenarioFile');
 
     function hideScenarioMenu() {
-        if (!scenarioControls.classList.contains('hidden')) {
-            scenarioControls.classList.add('hidden');
+        if (scenarioMenu.hasAttribute('open')) {
+            scenarioMenu.removeAttribute('open');
             scenarioToggle.setAttribute('aria-expanded', 'false');
         }
     }
 
-    scenarioToggle.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const hidden = scenarioControls.classList.toggle('hidden');
-        scenarioToggle.setAttribute('aria-expanded', String(!hidden));
+    scenarioMenu.addEventListener('toggle', () => {
+        scenarioToggle.setAttribute('aria-expanded', String(scenarioMenu.hasAttribute('open')));
     });
 
     document.addEventListener('click', (e) => {

--- a/public/script.js
+++ b/public/script.js
@@ -15,7 +15,12 @@ async function init() {
     const fileInput = document.getElementById('scenarioFile');
 
     scenarioToggle.addEventListener('click', () => {
-        scenarioControls.classList.toggle('hidden');
+        const hidden = scenarioControls.classList.toggle('hidden');
+        scenarioToggle.setAttribute('aria-expanded', String(!hidden));
+    });
+
+    fileInput.addEventListener('change', () => {
+        uploadBtn.disabled = !fileInput.files.length;
     });
 
     let scenario = {};

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,6 +22,8 @@ header {
     position: relative;
     text-align: center;
     margin-bottom: 30px;
+    padding-top: 10px;
+    padding-right: 60px; /* space for scenario button */
     color: white;
 }
 
@@ -342,8 +344,8 @@ header p {
 
 .scenario-menu {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 10px;
+    right: 10px;
     display: inline-block;
 }
 
@@ -361,8 +363,8 @@ header p {
     border: none;
     color: white;
     cursor: pointer;
-    font-size: 1.2rem;
-    padding: 6px;
+    font-size: 1.5rem;
+    padding: 8px;
 }
 
 .scenario-controls {

--- a/public/styles.css
+++ b/public/styles.css
@@ -385,13 +385,25 @@ header p {
     display: none;
 }
 
+
 .scenario-controls select {
-    padding: 6px;
+    padding: 8px;
+    min-width: 180px;
+    font-size: 1rem;
+}
+
+.scenario-controls label.menu-title {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 4px;
 }
 
 .btn-file,
 .scenario-upload-btn {
     display: inline-block;
+    width: 120px;
+    text-align: center;
+    box-sizing: border-box;
 }
 
 .scenario-upload-btn:disabled {

--- a/public/styles.css
+++ b/public/styles.css
@@ -340,12 +340,20 @@ header p {
     align-items: stretch;
 }
 
-/* Scenario selection menu */
 .scenario-menu {
     position: absolute;
     top: 0;
     right: 0;
     display: inline-block;
+}
+
+.scenario-menu summary {
+    list-style: none;
+    cursor: pointer;
+}
+
+.scenario-menu summary::-webkit-details-marker {
+    display: none;
 }
 
 .scenario-btn {
@@ -369,6 +377,10 @@ header p {
     gap: 8px;
     align-items: center;
     z-index: 10;
+}
+
+.scenario-menu:not([open]) .scenario-controls {
+    display: none;
 }
 
 .scenario-controls select {

--- a/public/styles.css
+++ b/public/styles.css
@@ -370,15 +370,26 @@ header p {
     padding: 6px;
 }
 
-.scenario-upload {
+.scenario-upload,
+.scenario-upload-btn,
+.btn-file {
     background: #00B5E2;
     color: #FFFFFF;
     border-radius: 6px;
     padding: 6px 12px;
     cursor: pointer;
 }
-.upload-label input {
-    display: none;
+
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .legend-topology .device-legend {

--- a/public/styles.css
+++ b/public/styles.css
@@ -19,6 +19,7 @@ body {
 }
 
 header {
+    position: relative;
     text-align: center;
     margin-bottom: 30px;
     color: white;
@@ -340,7 +341,9 @@ header p {
 
 /* Scenario selection menu */
 .scenario-menu {
-    position: relative;
+    position: absolute;
+    top: 0;
+    right: 0;
     display: inline-block;
 }
 
@@ -349,7 +352,8 @@ header p {
     border: none;
     color: white;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: 1.2rem;
+    padding: 6px;
 }
 
 .scenario-controls {

--- a/public/styles.css
+++ b/public/styles.css
@@ -262,7 +262,8 @@ header p {
 }
 
 .submit-btn:disabled {
-    opacity: 0.6;
+    background: #ccc;
+    color: #666;
     cursor: not-allowed;
     transform: none;
 }
@@ -374,14 +375,15 @@ header p {
     padding: 6px;
 }
 
-.scenario-upload,
-.scenario-upload-btn,
-.btn-file {
-    background: #00B5E2;
-    color: #FFFFFF;
-    border-radius: 6px;
-    padding: 6px 12px;
-    cursor: pointer;
+.btn-file,
+.scenario-upload-btn {
+    display: inline-block;
+}
+
+.scenario-upload-btn:disabled {
+    background: #ccc;
+    color: #666;
+    cursor: not-allowed;
 }
 
 .visually-hidden {

--- a/public/styles.css
+++ b/public/styles.css
@@ -376,8 +376,10 @@ header p {
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     display: flex;
+    flex-direction: column;
     gap: 8px;
-    align-items: center;
+    align-items: stretch;
+    width: 220px;
     z-index: 10;
 }
 
@@ -396,12 +398,13 @@ header p {
     display: block;
     font-weight: bold;
     margin-bottom: 4px;
+    color: #000;
 }
 
 .btn-file,
 .scenario-upload-btn {
     display: inline-block;
-    width: 120px;
+    width: 100%;
     text-align: center;
     box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- redesign scenario upload controls
- add hidden-accessible styles for screen readers
- toggle upload button based on file selection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416445bbc4832a9ea038c72bc674e9