### PR TITLE
Support per-ping status

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A scenario file describes all content shown in the UI. The example in `scenarios
 - `devices` – list of device IDs, names and descriptions
 - `topology` – Mermaid diagram syntax
 - `paths` – summary of the traffic flows
-- `test_results` – observed behaviours for the user to analyse
+- `test_results` – observed behaviours for the user to analyse (ping tests can specify `status` for each pair)
 - `hints` – progressive hints displayed on request
 - `validation` – the correct answer and feedback messages
 

--- a/public/script.js
+++ b/public/script.js
@@ -126,7 +126,26 @@ function populateScenario(data) {
 
             let pingHtml = `<h3>🏓 ${result.heading}</h3><div class="ping-results">`;
             result.results.forEach(r => {
-                pingHtml += `<div class="ping-item">${r} <span class="status-badge success">✅</span></div>`;
+                let text = r;
+                let status = 'success';
+
+                if (typeof r === 'object' && r !== null) {
+                    text = r.pair || r.test || r.name || r.target || '';
+                    status = r.status || 'success';
+                }
+
+                const lower = String(status).toLowerCase();
+                let badgeClass = '';
+                let icon = 'ℹ️';
+                if (['success', 'pass', 'working'].includes(lower)) {
+                    badgeClass = 'success';
+                    icon = '✅';
+                } else if (['failure', 'fail'].includes(lower)) {
+                    badgeClass = 'failure';
+                    icon = '❌';
+                }
+
+                pingHtml += `<div class="ping-item">${text} <span class="status-badge ${badgeClass}">${icon}</span></div>`;
             });
             pingHtml += '</div>';
             if (result.note) {

--- a/scenarios/default.yaml
+++ b/scenarios/default.yaml
@@ -115,18 +115,27 @@ test_results:
       - Packer: Packages accepted items only (receives none from savory).
 
   ping:
-    heading: "Machine‐to‐Machine Handshake Tests (All Working)"
+    heading: "Machine‐to‐Machine Handshake Tests"
     status: success
     results:
-      - "RM → SH"
-      - "SH → OV"
-      - "OV → SPT"
-      - "SPT → FR"
-      - "SPT → SPC"
-      - "FR → QC"
-      - "SPC → QC"
-      - "QC → SHD"
-      - "SHD → PK"
+      - pair: "RM → SH"
+        status: success
+      - pair: "SH → OV"
+        status: success
+      - pair: "OV → SPT"
+        status: success
+      - pair: "SPT → FR"
+        status: success
+      - pair: "SPT → SPC"
+        status: success
+      - pair: "FR → QC"
+        status: success
+      - pair: "SPC → QC"
+        status: success
+      - pair: "QC → SHD"
+        status: success
+      - pair: "SHD → PK"
+        status: success
   note: |
     All handshake tests succeed—no machine is physically offline or disconnected.
 


### PR DESCRIPTION
## Summary
- document ping status support in YAML scenario docs
- add `pair` + `status` fields in default scenario ping tests
- show pass/fail icons per ping result in the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684226d07e3c832a987aa6e5c8f880a7