### PR TITLE
Fix YAML formatting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   signal-routing-app:
     build: .

--- a/scenarios/image-generation.yaml
+++ b/scenarios/image-generation.yaml
@@ -1,7 +1,8 @@
+---
 title: "Image Processing Pipeline Troubleshooting Exercise"
 overview: |
   This simulation presents a real‐time image processing pipeline where camera feeds are normalized, split for parallel analytics,
-  and also sent for batch archival.  Real‐time analytics detect anomalies and generate alerts, while batch archives compress 
+  and also sent for batch archival.  Real‐time analytics detect anomalies and generate alerts, while batch archives compress
   images before storing.  Use the information below to identify the misbehaving device.
 
 devices:

--- a/scenarios/package-sorting.yaml
+++ b/scenarios/package-sorting.yaml
@@ -1,3 +1,4 @@
+---
 title: "Automated Package Sorting System Troubleshooting Exercise"
 overview: |
   This simulation presents an automated package sorting system. Incoming packages are conveyed in, scanned for destination,
@@ -76,13 +77,13 @@ test_results:
     heading: "Zone A Packages (Working)"
     status: success
     details: |
-      A batch of Zone A packages travels through InfeedConveyor → ScanStation → Diverter → SorterA → MergeStation 
+      A batch of Zone A packages travels through InfeedConveyor → ScanStation → Diverter → SorterA → MergeStation
       → WeightChecker → LabelPrinter → OutfeedConveyor and all reach the shipping dock correctly, with accurate weights and labels.
   zone_b:
     heading: "Zone B Packages (Failing)"
     status: failure
     details: |
-      A batch of Zone B packages follows InfeedConveyor → ScanStation → Diverter → SorterB → MergeStation 
+      A batch of Zone B packages follows InfeedConveyor → ScanStation → Diverter → SorterB → MergeStation
       → WeightChecker → LabelPrinter → OutfeedConveyor but never appear at MergeStation. They seem to stall immediately after Diverter.
   spot_checks:
     heading: "Spot‐Checks at Each Device"
@@ -131,4 +132,4 @@ hints:
 validation:
   correct_answer: "SB"
   success_feedback: "Correct! SorterB (SB) is faulty. Its handshake with the Diverter fails, and Zone B packages never exit toward MergeStation, confirming SorterB is the culprit."
-  failure_feedback: "Incorrect. The faulty device is SorterB (SB). The handshake test Diverter → SorterB fails, and Zone B packages stall at SorterB, while Zone A processing proceeds normally."```
+  failure_feedback: "Incorrect. The faulty device is SorterB (SB). The handshake test Diverter → SorterB fails, and Zone B packages stall at SorterB, while Zone A processing proceeds normally."

--- a/scenarios/sheet-production.yaml
+++ b/scenarios/sheet-production.yaml
@@ -1,3 +1,4 @@
+---
 title: "Production‐Line QualityCheck Troubleshooting Exercise"
 overview: |
   This simulation presents a production line where raw ingredients are mixed, formed into sheets, baked, and then routed into separate sweet and savory branches.


### PR DESCRIPTION
## Summary
- ensure all YAML files start with document indicator
- clean up stray backticks and trailing whitespace
- remove extraneous spaces in scenarios yaml files
- make docker-compose.yml and scenarios yamls start with `---`

## Testing
- `npm test` *(fails: Missing script)*
- `yamllint -d '{extends: default, rules: {line-length: disable}}' docker-compose.yml scenarios/package-sorting.yaml scenarios/sheet-production.yaml scenarios/image-generation.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684253d76064832aa8a58ab867fddb33